### PR TITLE
Use port 4200 for dev client server

### DIFF
--- a/grunt/webpack-dev-server.js
+++ b/grunt/webpack-dev-server.js
@@ -6,10 +6,11 @@ let clone = require('clone');
 let webpackConfig = clone(require('./webpack').options);
 
 // enable live reload without a script tag
-webpackConfig.entry.vendor.unshift('webpack-dev-server/client?http://localhost:8080');
+webpackConfig.entry.vendor.unshift('webpack-dev-server/client?http://localhost:4200');
 
 module.exports = {
   options: {
+    port: 4200,
     webpack: webpackConfig,
   },
 


### PR DESCRIPTION
Keep front end end-points consistent, `js-template`,`ember-template`

@jrhorn424 If you think this is okay, please merge to master.

