### PR TITLE
Clean unnecessary trailing `^M`s from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,7 @@ jspm_packages
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
Match other template versions except for webpack specifics.

Close #46