### PR TITLE
Ensure `node_modules` is excluded from scss linting.

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+exclude: 'node_modules/*'


### PR DESCRIPTION
bootstrap-sass, node-sass, etc.

For slow machines not having this may generate bug notices in atom.