### PR TITLE
Fix for "vendor" in js filename exclusion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tmp
 dist
+dependencies.js
 vendor.js
 specs.js
 *bundle.js

--- a/grunt/webpack.js
+++ b/grunt/webpack.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     plugins: [
-      new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js'),
+      new webpack.optimize.CommonsChunkPlugin('vendor', 'dependencies.js'),
       new webpack.ProvidePlugin({
         $: 'jquery',
         jQuery: 'jquery',

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
       <meta name="viewport" content="width=device-width, initial-scale=1">
 
-      <script src="vendor.bundle.js" type="text/javascript" charset="utf-8" defer></script>
+      <script src="dependencies.js" type="text/javascript" charset="utf-8" defer></script>
       <script src="bundle.js" type="text/javascript" charset="utf-8" defer></script>
     </head>
     <body class="container-fluid">


### PR DESCRIPTION
github pages seems to be preventing files with "vendor" in the name
from being served.