### PR TITLE
Build as second step for deploy.

### DIFF
--- a/grunt/aliases.json
+++ b/grunt/aliases.json
@@ -2,6 +2,7 @@
   "default": ["nag"],
   "deploy": [
     "shell:git-is-clean",
+    "build",
     "shell:git-push-master",
     "shell:deploy-prepare",
     "build",

--- a/grunt/shell.js
+++ b/grunt/shell.js
@@ -8,7 +8,7 @@ const ghPagesList = [
 
 module.exports = {
   'git-is-clean': {
-    // `$(git status --porcelain)` will evaluate to the empty string if the 
+    // `$(git status --porcelain)` will evaluate to the empty string if the
     // working directory is clean.
     // `test -z` will exit 0 (true) if its argument is an empty string.
     // If it doesn't exit true, `(git status && false)` will show why the


### PR DESCRIPTION
Some developers try to deploy code that has not been sniff-tested.